### PR TITLE
changed project groupId com.movilepay -> com.github.movilepay

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.movilepay</groupId>
+    <groupId>com.github.movilepay</groupId>
     <artifactId>kt-mapper</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
 
 </project>

--- a/src/main/kotlin/com/github/movilepay/ktmapper/KtMapper.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/KtMapper.kt
@@ -1,8 +1,8 @@
-package com.movilepay.ktmapper
+package com.github.movilepay.ktmapper
 
-import com.movilepay.ktmapper.helpers.KtMapperInternalHelper
-import com.movilepay.ktmapper.mappings.MappingConfigurationBase
-import com.movilepay.ktmapper.reflection.Reflection
+import com.github.movilepay.ktmapper.helpers.KtMapperInternalHelper
+import com.github.movilepay.ktmapper.mappings.MappingConfigurationBase
+import com.github.movilepay.ktmapper.reflection.Reflection
 import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty

--- a/src/main/kotlin/com/github/movilepay/ktmapper/helpers/KtMapperInternalHelper.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/helpers/KtMapperInternalHelper.kt
@@ -1,6 +1,6 @@
-package com.movilepay.ktmapper.helpers
+package com.github.movilepay.ktmapper.helpers
 
-import com.movilepay.ktmapper.reflection.Reflection
+import com.github.movilepay.ktmapper.reflection.Reflection
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty
 

--- a/src/main/kotlin/com/github/movilepay/ktmapper/mappings/DefaultMappingConfiguration.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/mappings/DefaultMappingConfiguration.kt
@@ -1,4 +1,4 @@
-package com.movilepay.ktmapper.mappings
+package com.github.movilepay.ktmapper.mappings
 
 import kotlin.reflect.KProperty
 

--- a/src/main/kotlin/com/github/movilepay/ktmapper/mappings/MapForProperty.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/mappings/MapForProperty.kt
@@ -1,4 +1,4 @@
-package com.movilepay.ktmapper.mappings
+package com.github.movilepay.ktmapper.mappings
 
 import kotlin.reflect.KProperty
 

--- a/src/main/kotlin/com/github/movilepay/ktmapper/mappings/MappingConfigurationBase.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/mappings/MappingConfigurationBase.kt
@@ -1,7 +1,7 @@
-package com.movilepay.ktmapper.mappings
+package com.github.movilepay.ktmapper.mappings
 
-import com.movilepay.ktmapper.KtMapper
-import com.movilepay.ktmapper.helpers.KtMapperInternalHelper
+import com.github.movilepay.ktmapper.KtMapper
+import com.github.movilepay.ktmapper.helpers.KtMapperInternalHelper
 import kotlin.reflect.KProperty
 
 abstract class MappingConfigurationBase<

--- a/src/main/kotlin/com/github/movilepay/ktmapper/reflection/Reflection.kt
+++ b/src/main/kotlin/com/github/movilepay/ktmapper/reflection/Reflection.kt
@@ -1,4 +1,4 @@
-package com.movilepay.ktmapper.reflection
+package com.github.movilepay.ktmapper.reflection
 
 import java.lang.reflect.Member
 import kotlin.reflect.KClass


### PR DESCRIPTION
## Problem
We are having trouble when trying to verify the ownership of domain `com.movilepay`.

## Solution
For now, I'm changing the groupId from `com.movilepay` to `com.github.movilepay` and after resolving the domain issues I'll change groupId to `com.movilepay`.

## Other changes
- Changed source code path from: `src/main/java/*` to `src/main/kotlin/*`
- Changed version to 0.0.1-SNAPSHOT